### PR TITLE
Improved Quote Text Objects

### DIFF
--- a/lib/text-objects.coffee
+++ b/lib/text-objects.coffee
@@ -32,16 +32,17 @@ class SelectInsideQuotes extends TextObject
     @lookForwardOnLine(start)
 
   isStartQuote: (end) ->
-    range = new Range([0,0],end)
-    numQuotes = range.toString().replace('\''+@char,'').split(@char).length-1
+    line = @editor.lineForBufferRow(end.row)
+    numQuotes = line.substring(0,end.column + 1).replace('\''+@char,'').split(@char).length-1
     return numQuotes % 2
 
 
   lookForwardOnLine: (pos) ->
     line = @editor.lineForBufferRow(pos.row)
-    idx = line.indexOf @char
+
+    idx = line.substring(pos.column).indexOf @char
     if idx >= 0
-      pos.column = idx
+      pos.column += idx
       return pos
     null
 

--- a/lib/text-objects.coffee
+++ b/lib/text-objects.coffee
@@ -19,27 +19,31 @@ class SelectInsideQuotes extends TextObject
   findOpeningQuote: (pos) ->
     start = pos.copy()
     pos = pos.copy()
-    numQuotes = 0
     while pos.row >= 0
       line = @editor.lineForBufferRow(pos.row)
       pos.column = line.length - 1 if pos.column == -1
       while pos.column >= 0
         if line[pos.column] == @char
-          unEscaped = pos.column == 0 or line[pos.column - 1] != '\\'
-          if unEscaped
-            numQuotes++
-          result = pos.copy() if not result and unEscaped
+          if pos.column == 0 or line[pos.column - 1] != '\\'
+            return if @isStartQuote(pos) then pos else @lookForwardOnLine(start)
         -- pos.column
       pos.column = -1
       -- pos.row
-     if numQuotes % 2 then result else @lookForwardOnLine(start)
+    @lookForwardOnLine(start)
+
+  isStartQuote: (end) ->
+    range = new Range([0,0],end)
+    numQuotes = range.toString().replace('\''+@char,'').split(@char).length-1
+    return numQuotes % 2
+
 
   lookForwardOnLine: (pos) ->
     line = @editor.lineForBufferRow(pos.row)
-    while pos.column < line.length
-      if line[pos.column] == @char
-        return pos
-      pos.column++
+    idx = line.indexOf @char
+    if idx >= 0
+      pos.column = idx
+      return pos
+    null
 
   findClosingQuote: (start) ->
     end = start.copy()

--- a/lib/text-objects.coffee
+++ b/lib/text-objects.coffee
@@ -17,16 +17,29 @@ class SelectInsideQuotes extends TextObject
   constructor: (@editor, @char, @includeQuotes) ->
 
   findOpeningQuote: (pos) ->
+    start = pos.copy()
     pos = pos.copy()
+    numQuotes = 0
     while pos.row >= 0
       line = @editor.lineForBufferRow(pos.row)
       pos.column = line.length - 1 if pos.column == -1
       while pos.column >= 0
         if line[pos.column] == @char
-          return pos if pos.column == 0 or line[pos.column - 1] != '\\'
+          unEscaped = pos.column == 0 or line[pos.column - 1] != '\\'
+          if unEscaped
+            numQuotes++
+          result = pos.copy() if not result and unEscaped
         -- pos.column
       pos.column = -1
       -- pos.row
+     if numQuotes % 2 then result else @lookForwardOnLine(start)
+
+  lookForwardOnLine: (pos) ->
+    line = @editor.lineForBufferRow(pos.row)
+    while pos.column < line.length
+      if line[pos.column] == @char
+        return pos
+      pos.column++
 
   findClosingQuote: (start) ->
     end = start.copy()

--- a/spec/text-objects-spec.coffee
+++ b/spec/text-objects-spec.coffee
@@ -146,51 +146,70 @@ describe "TextObjects", ->
 
   describe "the 'i\'' text object", ->
     beforeEach ->
-      editor.setText("' something in here and in 'here' '")
+      editor.setText("' something in here and in 'here' ' and over here")
       editor.setCursorScreenPosition([0, 9])
 
-    it "applies operators inside the current word in operator-pending mode", ->
+    it "applies operators inside the current string in operator-pending mode", ->
       keydown('d')
       keydown('i')
       keydown('\'')
-      expect(editor.getText()).toBe "''here' '"
+      expect(editor.getText()).toBe "''here' ' and over here"
       expect(editor.getCursorScreenPosition()).toEqual [0, 1]
       expect(editorView).not.toHaveClass('operator-pending-mode')
       expect(editorView).toHaveClass('command-mode')
 
-    it "applies operators inside the current word in operator-pending mode (second test)", ->
+    it "applies operators inside the next string in operator-pending mode (if not in a string)", ->
       editor.setCursorScreenPosition([0, 29])
       keydown('d')
       keydown('i')
       keydown('\'')
-      expect(editor.getText()).toBe "' something in here and in '' '"
-      expect(editor.getCursorScreenPosition()).toEqual [0, 28]
+      expect(editor.getText()).toBe "' something in here and in 'here'' and over here"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 33]
+      expect(editorView).not.toHaveClass('operator-pending-mode')
+      expect(editorView).toHaveClass('command-mode')
+
+    it "makes no change if past the last string on a line", ->
+      editor.setCursorScreenPosition([0, 39])
+      keydown('d')
+      keydown('i')
+      keydown('\'')
+      expect(editor.getText()).toBe "' something in here and in 'here' ' and over here"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 39]
       expect(editorView).not.toHaveClass('operator-pending-mode')
       expect(editorView).toHaveClass('command-mode')
 
   describe "the 'i\"' text object", ->
     beforeEach ->
-      editor.setText("\" something in here and in \"here\" \"")
+      editor.setText("\" something in here and in \"here\" \" and over here")
       editor.setCursorScreenPosition([0, 9])
 
-    it "applies operators inside the current word in operator-pending mode", ->
+    it "applies operators inside the current string in operator-pending mode", ->
       keydown('d')
       keydown('i')
-      keydown('""')
-      expect(editor.getText()).toBe '""here" "'
+      keydown('"')
+      expect(editor.getText()).toBe "\"\"here\" \" and over here"
       expect(editor.getCursorScreenPosition()).toEqual [0, 1]
       expect(editorView).not.toHaveClass('operator-pending-mode')
       expect(editorView).toHaveClass('command-mode')
 
-    it "applies operators inside the current word in operator-pending mode (second test)", ->
+    it "applies operators inside the next string in operator-pending mode (if not in a string)", ->
       editor.setCursorScreenPosition([0, 29])
       keydown('d')
       keydown('i')
       keydown('"')
-      expect(editor.getText()).toBe "\" something in here and in \"\" \""
-      expect(editor.getCursorScreenPosition()).toEqual [0, 28]
+      expect(editor.getText()).toBe "\" something in here and in \"here\"\" and over here"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 33]
       expect(editorView).not.toHaveClass('operator-pending-mode')
       expect(editorView).toHaveClass('command-mode')
+
+    it "makes no change if past the last string on a line", ->
+      editor.setCursorScreenPosition([0, 39])
+      keydown('d')
+      keydown('i')
+      keydown('"')
+      expect(editor.getText()).toBe "\" something in here and in \"here\" \" and over here"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 39]
+      expect(editorView).not.toHaveClass('operator-pending-mode')
 
   describe "the 'aw' text object", ->
     beforeEach ->
@@ -330,8 +349,8 @@ describe "TextObjects", ->
       keydown('d')
       keydown('a')
       keydown('\'')
-      expect(editor.getText()).toBe "' something in here and in  '"
-      expect(editor.getCursorScreenPosition()).toEqual [0, 27]
+      expect(editor.getText()).toBe "' something in here and in 'here"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 31]
       expect(editorView).not.toHaveClass('operator-pending-mode')
       expect(editorView).toHaveClass('command-mode')
 
@@ -354,7 +373,7 @@ describe "TextObjects", ->
       keydown('d')
       keydown('a')
       keydown('"')
-      expect(editor.getText()).toBe "\" something in here and in  \""
-      expect(editor.getCursorScreenPosition()).toEqual [0, 27]
+      expect(editor.getText()).toBe "\" something in here and in \"here"
+      expect(editor.getCursorScreenPosition()).toEqual [0, 31]
       expect(editorView).not.toHaveClass('operator-pending-mode')
       expect(editorView).toHaveClass('command-mode')

--- a/spec/text-objects-spec.coffee
+++ b/spec/text-objects-spec.coffee
@@ -13,7 +13,7 @@ describe "TextObjects", ->
 
       vimState = editorView.vimState
       vimState.activateCommandMode()
-      vimState.resetCommandMode()jj
+      vimState.resetCommandMode()
 
   keydown = (key, options={}) ->
     options.element ?= editorView[0]

--- a/spec/text-objects-spec.coffee
+++ b/spec/text-objects-spec.coffee
@@ -13,7 +13,7 @@ describe "TextObjects", ->
 
       vimState = editorView.vimState
       vimState.activateCommandMode()
-      vimState.resetCommandMode()
+      vimState.resetCommandMode()jj
 
   keydown = (key, options={}) ->
     options.element ?= editorView[0]


### PR DESCRIPTION
This is a first stab at fixing the issues I raised in #379.  Commands like
`ci'` and `ca"` now behave as expected when outside of a string.  

I've updated the tests to check for the right behavior and wrote an initial implementation.
Unfortunately my first take is pretty hopelessly naive.
I'm iterating all the way back through the file to count quote marks to tell if I'm inside 
a quote or between 2 strings.  I'd love feedback from somebody with a better
knowledge of Atom internals/APIs about what I can do better to avoid running up the whole file,
there's a noticeable lag when using these text objects at the end of large files right now.

Clumping up the whole earlier text into a string, removing escaped quotes and filtering other characters 
would probably be more efficient but still slow.  I'd love any feedback from Atom experts on how to make this better.
